### PR TITLE
fix build error: Type 'Uint8Array' is not assignable to type 'string'.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -693,7 +693,7 @@ function isWithinCurveOrder(num: bigint): boolean {
 function normalizePrivateKey(key: PrivKey): Uint8Array {
   let num: bigint;
   if (typeof key === 'bigint' || (Number.isSafeInteger(key) && key > 0)) {
-    num = BigInt(key);
+    num = BigInt(key as bigint);
     key = num.toString(16).padStart(B32 * 2, '0');
   }
   if (typeof key === 'string') {


### PR DESCRIPTION
got following error while `yarn build`:

```
yarn run v1.22.10
$ tsc -d
index.ts:696:18 - error TS2345: Argument of type 'PrivKey' is not assignable to parameter of type 'string | number | bigint | boolean'.
  Type 'Uint8Array' is not assignable to type 'string | number | bigint | boolean'.
    Type 'Uint8Array' is not assignable to type 'string'.

696     num = BigInt(key);
                     ~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

![image](https://user-images.githubusercontent.com/171268/120003335-3a944900-c008-11eb-9d17-e0d1243f4453.png)
