### PR TITLE
Add "browser" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.3",
   "description": "Fastest JS implementation of ed25519 & ristretto255. Auditable, high-security, 0-dependency pubkey, scalarmult & EDDSA",
   "main": "index.js",
+  "browser": {
+    "crypto": false
+  },
   "files": [
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
`browser: { crypto: false }` in the `package.json` indicates to browsers that `require("crypto")` imports don't have to be loaded,
they'll be faked as `{}` objects.

This has been specified here: https://github.com/defunctzombie/package-browser-field-spec

And since been implemented by:
* webpack: https://webpack.js.org/configuration/resolve/#resolvemainfields
* vite: https://github.com/vitejs/vite/pull/301
* snowpack (tested manually)
* esbuild: https://esbuild.github.io/getting-started/#bundling-for-the-browser
And probably many more.