### PR TITLE
Support service workers by using 'self' instead of 'window'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -759,9 +759,9 @@ export const utils = {
   ],
   randomPrivateKey: (bytesLength: number = 32): Uint8Array => {
     // @ts-ignore
-    if (typeof window == 'object' && 'crypto' in window) {
+    if (typeof self == 'object' && 'crypto' in self) {
       // @ts-ignore
-      return window.crypto.getRandomValues(new Uint8Array(bytesLength));
+      return self.crypto.getRandomValues(new Uint8Array(bytesLength));
       // @ts-ignore
     } else if (typeof process === 'object' && 'node' in process.versions) {
       // @ts-ignore
@@ -773,9 +773,9 @@ export const utils = {
   },
   sha512: async (message: Uint8Array): Promise<Uint8Array> => {
     // @ts-ignore
-    if (typeof window == 'object' && 'crypto' in window) {
+    if (typeof self == 'object' && 'crypto' in self) {
       // @ts-ignore
-      const buffer = await window.crypto.subtle.digest('SHA-512', message.buffer);
+      const buffer = await self.crypto.subtle.digest('SHA-512', message.buffer);
       // @ts-ignore
       return new Uint8Array(buffer);
       // @ts-ignore


### PR DESCRIPTION
Fixes #25. Using `self` instead of `window` [is supported in all major browsers](https://caniuse.com/mdn-api_window_self) and works in service workers too.