### PR TITLE
add type declarations to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.6",
   "description": "Fastest JS implementation of ed25519 & ristretto255. Auditable, high-security, 0-dependency pubkey, scalarmult & EDDSA",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
This should allow automatic type resolution in Deno, when imported from esm.sh or skypack.dev