### PR TITLE
Remove doc reference to unimplemented Point.fromY()

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ ed25519.Point.BASE // new ed25519.Point(Gx, Gy) where
 // Elliptic curve point in Affine (x, y) coordinates.
 ed25519.Point {
   constructor(x: bigint, y: bigint);
-  static fromY(y: bigint);
   static fromHex(hash: string);
   static fromPrivateKey(privateKey: string | Uint8Array);
   toX25519(): bigint; // Converts to Curve25519 u coordinate


### PR DESCRIPTION
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/6340841/149844202-577b54c3-64bf-4092-8e18-6725d6bc1d53.png">

The readme documents a method `Point.fromY(y: bigint)`, but there are no references to this method anywhere else in the codebase or typings.

Is this meant to be added?

This PR is one simple fix, to at least remove it from the docs until properly implemented.