### PR TITLE
Fix point.multiply(CURVE.l) for subgroup check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -749,7 +749,7 @@ function normalizeScalar(num: number | bigint, max: bigint, strict = true): bigi
   if (!max) throw new TypeError('Specify max value');
   if (typeof num === 'bigint') {
     if (strict) {
-      if (_0n < num && num < max) return num;
+      if (_0n < num && num <= max) return num;
     } else {
       if (_0n <= num && num < MAX_256B) return num;
     }
@@ -761,7 +761,7 @@ function normalizeScalar(num: number | bigint, max: bigint, strict = true): bigi
       if (0 <= num) return BigInt(num);
     }
   }
-  throw new TypeError('Expected valid scalar: 0 < scalar < max');
+  throw new TypeError('Expected valid scalar: 0 < scalar <= max');
 }
 
 function adjustBytes25519(bytes: Uint8Array): Uint8Array {


### PR DESCRIPTION
To confirm a point `p` is in the prime order subgroup, we check `p.multiply(CURVE.l).equals(Point.zero)`.

But currently such a check throws the error `Expected valid scalar: 0 < scalar < max`, from https://github.com/paulmillr/noble-ed25519/blob/17144f066ed171697fae7f94d92c759b3bb84061/index.ts#L764

This PR adjusts the `normalizeScalar()` max check to use `<=`, instead of `<`, which fixes the issue.