### PR TITLE
Add RistrettoPoint.subtract(other: RistrettoPoint)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -421,6 +421,10 @@ class RistrettoPoint {
     return new RistrettoPoint(this.ep.add(other.ep));
   }
 
+  subtract(other: RistrettoPoint): RistrettoPoint {
+    return new RistrettoPoint(this.ep.subtract(other.ep));
+  }
+
   multiply(scalar: number | bigint): RistrettoPoint {
     return new RistrettoPoint(this.ep.multiply(scalar));
   }


### PR DESCRIPTION
Adds missing `RistrettoPoint.subtract(other: RistrettoPoint)` method, following same pattern as .add() and .multiply(), in same order as ExtendedPoint: add(), subtract(), then multiply()