### PR TITLE
Make RistrettoPoint.ep public

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -304,7 +304,7 @@ class RistrettoPoint {
   static BASE = new RistrettoPoint(ExtendedPoint.BASE);
   static ZERO = new RistrettoPoint(ExtendedPoint.ZERO);
 
-  constructor(private readonly ep: ExtendedPoint) {}
+  constructor(readonly ep: ExtendedPoint) {}
 
   // Computes Elligator map for Ristretto
   // https://ristretto.group/formulas/elligator.html


### PR DESCRIPTION
I needed a way to go from a `RistrettoPoint` back to `ExtendedPoint`, and then back to `Point`.

This simple change makes it possible:

```ts
RistrettoPoint.ep.toAffine()
```

Was there some reason I didn't understand why this field was private?