### PR TITLE
Export utils.invert(number, (mod))

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ utils.sha512(message: Uint8Array): Promise<Uint8Array>;
 // Modular division
 utils.mod(number: bigint, modulo = CURVE.P): bigint;
 
+// Inverses number over modulo
+utils.invert(number: bigint, modulo = CURVE.P): bigint;
+
 // Convert Uint8Array to hex string
 utils.bytesToHex(bytes: Uint8Array): string;
 

--- a/index.ts
+++ b/index.ts
@@ -1056,6 +1056,7 @@ export const utils = {
   bytesToHex,
   getExtendedPublicKey,
   mod,
+  invert,
 
   /**
    * Can take 40 or more bytes of uniform input e.g. from CSPRNG or KDF


### PR DESCRIPTION
Export the existing `invert()` function in `utils`

https://github.com/paulmillr/noble-ed25519/blob/a08955c9b15648f3f7ff5beaecbb0b0156bb5a65/index.ts#L672

And adds it to the README docs