### PR TITLE
Expose RistrettoPoint.multiplyUnsafe()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -430,6 +430,10 @@ class RistrettoPoint {
   multiply(scalar: number | bigint): RistrettoPoint {
     return new RistrettoPoint(this.ep.multiply(scalar));
   }
+
+  multiplyUnsafe(scalar: number | bigint): RistrettoPoint {
+    return new RistrettoPoint(this.ep.multiplyUnsafe(scalar));
+  }
 }
 
 // Stores precomputed values for points.


### PR DESCRIPTION
We're using this to speed up ZK verification times (as mentioned here: https://github.com/paulmillr/noble-ed25519/pull/54#issuecomment-1029492700)