### PR TITLE
Add RistrettoPoint.toString() method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -409,6 +409,10 @@ class RistrettoPoint {
     return bytesToHex(this.toRawBytes());
   }
 
+  toString(): string {
+    return this.toHex();
+  }
+
   // Compare one point to another.
   equals(other: RistrettoPoint): boolean {
     const a = this.ep;


### PR DESCRIPTION
This adds `.toString()` as an alias of `.toHex()`, so that points can be automatically stringified when passed to `console.log()`, or `.join()` over an array of them, etc.