### PR TITLE
Fix: skypack build

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@
 
 // Uses built-in crypto module from node.js to generate randomness / hmac-sha256.
 // In browser the line is automatically removed during build time: uses crypto.subtle instead.
-import nodeCrypto from 'crypto';
+import * as nodeCrypto from 'crypto';
 
 // Be friendly to bad ECMAScript parsers by not using bigint literals like 123n
 const _0n = BigInt(0);

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
   ],
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/index.js"
-    },
-    "./index.d.ts": "./lib/index.d.ts"
+    }
   },
   "prettier": {
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
     },
     "./index.d.ts": "./lib/index.d.ts"
   },
+  "prettier": {
+    "printWidth": 100,
+    "singleQuote": true
+  },
   "jest": {
     "testRegex": "/test/.*.ts",
     "transform": {

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,7 +3,7 @@ import * as ed from '../';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
-import { default as zip215 } from './zip215.json';
+import * as zip215 from './zip215.json';
 
 const hex = ed.utils.bytesToHex;
 


### PR DESCRIPTION
> This change is based on #65 which fixes failing tests that were introduce in https://github.com/paulmillr/noble-ed25519/commit/b34083f02d3ea1eb3bbb61ab525c2623a911280a

This change just fixes export maps as per https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing which fixes build errors on skypack see https://cdn.skypack.dev/@noble/ed25519

```
/*
 * [Package Error] "@noble/ed25519@v1.6.0" could not be built. 
 *
 *   [1/5] Verifying package is valid…
 *   [2/5] Installing dependencies from npm…
 *   [3/5] Building package using esinstall…
 *   Running esinstall...
 *   Cannot find module '@noble/ed25519/index.d.ts'
 *
 * How to fix:
 *   - If you believe this to be an error in Skypack, file an issue here: https://github.com/skypackjs/skypack-cdn/issues
 *   - If you believe this to be an issue in the package, share this URL with the package authors to help them debug & fix.
 *   - Use https://skypack.dev/ to find a web-friendly alternative to find another package.
 */

console.warn("[Package Error] \"@noble/ed25519@v1.6.0\" could not be built. \n[1/5] Verifying package is valid…\n[2/5] Installing dependencies from npm…\n[3/5] Building package using esinstall…\nRunning esinstall...\nCannot find module '@noble/ed25519/index.d.ts'");
throw new Error("[Package Error] \"@noble/ed25519@v1.6.0\" could not be built. ");
export default null;
```

I believe skypack uses esbuild which in turns looks at export maps.

