### PR TITLE
fix(crypto-error): add stricter check on crypto methods and throw error if undefined

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -277,12 +277,12 @@ const etc = {
     const crypto = cr(); // Can be shimmed in node.js <= 18 to prevent error:
     // import { webcrypto } from 'node:crypto';
     // if (!globalThis.crypto) globalThis.crypto = webcrypto;
-    if (!crypto) err('crypto.getRandomValues must be defined');
+    if (!crypto?.getRandomValues) err('crypto.getRandomValues must be defined');
     return crypto.getRandomValues(u8n(len));
   },
   sha512Async: async (...messages: Bytes[]): Promise<Bytes> => {
     const crypto = cr();
-    if (!crypto) err('crypto.subtle or etc.sha512Async must be defined');
+    if (!crypto?.subtle) err('crypto.subtle or etc.sha512Async must be defined');
     const m = concatB(...messages);
     return u8n(await crypto.subtle.digest('SHA-512', m.buffer));
   },


### PR DESCRIPTION
### Context

This adds a stricter  check on crypto methods and throws an error if necessary methods are undefined.

For example, I used [react-native-quick-crypto](https://www.npmjs.com/package/react-native-quick-crypto) to polyfill crypto on react-native but `crypto.subtle` was `undefined`.
It took me quite some time to find the root cause of [the issue](https://github.com/paulmillr/noble-ed25519/issues/91#issuecomment-1591201039) but this improved error handling should provide more indication on what is the issue than the current generic error `Cannot read property 'digest' of undefined`.