### PR TITLE
Noble-ed25519, does not handle the point at infinity in the toAffine method

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,8 @@ class Point {
     }
     toAffine() {
         const { ex: x, ey: y, ez: z } = this; // (x, y, z, t) ∋ (x=x/z, y=y/z, t=xy)
-        if (this.is0())
-            return { x: 0n, y: 0n }; // fast-path for zero point
+        if (this.equals(I))
+            return { x: 0n, y: 1n }; // fast-path for zero point
         const iz = invert(z); // z^-1: invert z
         if (mod(z * iz) !== 1n)
             err('invalid inverse'); // (z * z^-1) must be 1, otherwise bad math

--- a/index.ts
+++ b/index.ts
@@ -99,7 +99,7 @@ class Point {                                           // Point in xyzt extende
   }
   toAffine(): AffinePoint {                             // converts point to 2d xy affine point
     const { ex: x, ey: y, ez: z } = this;               // (x, y, z, t) ∋ (x=x/z, y=y/z, t=xy)
-    if (this.is0()) return { x: 0n, y: 0n };            // fast-path for zero point
+    if (this.equals(I)) return { x: 0n, y: 1n };        // fast-path for zero point
     const iz = invert(z);                               // z^-1: invert z
     if (mod(z * iz) !== 1n) err('invalid inverse');     // (z * z^-1) must be 1, otherwise bad math
     return { x: mod(x * iz), y: mod(y * iz) }           // x = x*z^-1; y = y*z^-1

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@noble/hashes": "1.3.0",
+        "@noble/hashes": "1.3.2",
         "fast-check": "3.0.0",
         "micro-bmark": "0.3.0",
         "micro-should": "0.4.0",
@@ -20,16 +20,16 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/fast-check": {
       "version": "3.0.0",


### PR DESCRIPTION
In the current implementation of the `toAffine` method within the `@noble-ed25519` library, there is an incorrect handling of the point at infinity O when transforming from projective to affine coordinates. Specifically, the point at infinity is incorrectly encoded as `(0, 0)` for the ed25519 curve.

```typescript
if (this.is0()) return { x: 0n, y: 0n }; 
```
 
However, for the ed25519 curve, the point at infinity should be represented by (0, 1) in affine coordinates to satisfy the curve equation and ensure correct computations during export and import operations.

We can fix it by doing this : 
```typescript
if (this.equals(I)) return { x: 0n, y: 1n };
```
           
Solved with @Elli610