### PR TITLE
test: label tests dir as having sideEffects=true

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": true
+}


### PR DESCRIPTION
This package is labelled as `sideEffects=false`:
https://github.com/paulmillr/noble-ed25519/blob/0a2838ff06f537ebc05c5be205712902d0220c44/package.json#L10-L14

That shouldn't apply to tests, because of:
1. This bare import: https://github.com/paulmillr/noble-ed25519/blob/0a2838ff06f537ebc05c5be205712902d0220c44/test/ed25519.webcrypto.test.js#L5
2. This setup (which is required): https://github.com/paulmillr/noble-ed25519/blob/0a2838ff06f537ebc05c5be205712902d0220c44/test/ed25519.helpers.js#L8

Adding `sideEffects=true` to the test dir makes tests suitable for running in bundled mode

To test:
* [x] `npm test`
* [ ] CI 
* [x] `npx @exodus/test` (Node.js)
* [x] `npx @exodus/test --engine jsc:bundle --bundle-entropy-size=1000000` (JSC)
     Requires `jsc` available in PATH
* [x] `npx @exodus/test --engine hermes:bundle --bundle-entropy-size=1000000` (Hermes) 
     Requires `hermes` available in PATH or https://npmjs.com/hermes-engine-cli installed with `@exodus/test`:
   `npm add @exodus/test hermes-engine-cli`